### PR TITLE
Add anti-periodic boundary condition for heisenberg interaction

### DIFF
--- a/scripts/job.jl
+++ b/scripts/job.jl
@@ -7,9 +7,9 @@ using LinearAlgebra
 using ArnoldiMethod
 
 tm = TaskMaker()
-tm.thermalization = 5000
-tm.sweeps = 200000
-tm.binsize = 10
+tm.thermalization = 5_000
+tm.sweeps = 20_000_000
+tm.binsize = 1
 tm.n1 = 8
 tm.n2 = 8
 ns = tm.n1 * tm.n2 * 3
@@ -47,13 +47,13 @@ task(tm; N_up = ns ÷ 2, N_down = ns ÷ 2)
 
 dir = @__DIR__
 # savepath = dir * "/../data/" * Dates.format(Dates.now(), "mm-ddTHH-MM-SS")
-savepath = dir * "/../data/" * "sign-$(tm.n1)x$(tm.n2)"
+savepath = dir * "/../data/" * "BC-$(tm.n1)x$(tm.n2)"
 job = JobInfo(
     savepath,
     KagomeDSL.MC;
     tasks = make_tasks(tm),
     checkpoint_time = "30:00",
-    run_time = "24:00:00",
+    run_time = "96:00:00",
 )
 
 Carlo.start(job, ARGS)

--- a/test/test-Hamiltonian.jl
+++ b/test/test-Hamiltonian.jl
@@ -107,8 +107,11 @@ end
     xprime = KagomeDSL.getxprime(ham, kappa_up, kappa_down)
     @test length(keys(xprime)) == 3
     # Sz interaction
-    Sz_sum = (length(DK.nn) - 2) * (1 / 2)
-    Sz_sum += 2 * (2 * (-1 / 4))
+    H = KagomeDSL.Hmat(DK)
+    negative_bonds_num = count(==(1.0), H) / 2
+    Sz_sum = (length(DK.nn) - negative_bonds_num - 2) * (1 / 4) * 2
+    Sz_sum += negative_bonds_num * (-1 / 4) * 2
+    Sz_sum += 2 * (2 * (-1 / 4)) # not affected by anti-PBC
     @test xprime[(-1, -1, -1, -1)] == Sz_sum
     # Sx Sy interaction, only happens in the bonds having site 1
     Sx_Sy_sum = 0.0

--- a/test/test-MonteCarlo.jl
+++ b/test/test-MonteCarlo.jl
@@ -236,7 +236,7 @@ end
         # Create a simple 2x2 test case
         U_up = [1.0 0.2; 0.2 1.0]
         U_down = [1.0 0.3; 0.3 1.0]
-        ham = Hamiltonian(1, 1, U_up, U_down, zeros(4, 4), [])
+        ham = Hamiltonian(1, 1, U_up, U_down, zeros(4, 4), zeros(4, 4), zeros(4, 4))
         kappa_up = [1, 2]
         kappa_down = [2, 1]
         mc = MC(ham, kappa_up, kappa_down, zeros(2, 2), zeros(2, 2))
@@ -262,7 +262,7 @@ end
         U_up = (U_up + U_up') / 2  # Make symmetric
         U_down = (U_down + U_down') / 2
 
-        ham = Hamiltonian(2, 2, U_up, U_down, zeros(16, 16), [])
+        ham = Hamiltonian(2, 2, U_up, U_down, zeros(16, 16), zeros(16, 16), zeros(16, 16))
         kappa_up = [1, 2, 3, 4]
         kappa_down = [4, 3, 2, 1]
         mc = MC(ham, kappa_up, kappa_down, zeros(n, n), zeros(n, n))


### PR DESCRIPTION
<!--
Thanks for making a pull request to KagomeDSL.jl.
We have added this PR template to help you help us.
Make sure to read the contributing guidelines and abide by the code of conduct.
See the comments below, fill the required fields, and check the items.
-->

## Related issues

<!-- We normally work with (i) create issue; (ii) discussion if necessary; (iii) create PR. So, at least one of the following should be true:-->

<!-- Option 1, this closes an existing issue. Fill the number below-->
Closes #
I think if the mean field ansatz uses a mixing boundary condition, and the real Hamiltonian should obey the same, otherwise, a symmetry may be broken.
<!-- Option 2, this is a small fix that arguably won't need an issue. Uncomment below -->
<!--
There is no related issue.
-->

## Checklist

<!-- mark true if NA -->
<!-- leave PR as draft until all is checked -->
- [ ] I am following the [contributing guidelines](https://github.com/hz-xiaxz/KagomeDSL.jl/blob/main/docs/src/90-contributing.md)
- [ ] Tests are passing
- [ ] Lint workflow is passing
- [ ] Docs were updated and workflow is passing
