### PR TITLE
Avoid overflow using QR

### DIFF
--- a/src/MonteCarlo.jl
+++ b/src/MonteCarlo.jl
@@ -214,7 +214,7 @@ end
 Finds a non-singular initial configuration for the MC simulation.
 This version uses a deterministic QR-based method and should not require retries.
 """
-function find_initial_configuration!(mc::MC, rng::AbstractRNG, ns::Int, N_up::Int, n1::Int)
+function find_initial_configuration!(mc::MC, ns::Int, N_up::Int)
     init_conf_qr!(mc, ns, N_up)
 
     tilde_U_up = tilde_U(mc.Ham.U_up, mc.kappa_up)
@@ -257,7 +257,7 @@ Initialize the Monte Carlo object
     n2 = params[:n2]
     ns = n1 * n2 * 3
     N_up = params[:N_up]
-    find_initial_configuration!(mc, ctx.rng, ns, N_up, n1)
+    find_initial_configuration!(mc, ns, N_up)
 end
 
 function Z(nn::AbstractArray, kappa_up::AbstractVector, kappa_down::AbstractVector)


### PR DESCRIPTION
<!--
Thanks for making a pull request to KagomeDSL.jl.
We have added this PR template to help you help us.
See the comments below, fill the required fields, and check the items.
-->

## Related issues

<!-- We normally work with (i) create issue; (ii) discussion if necessary; (iii) create PR. So, at least one of the following should be true:-->

<!-- Option 1, this closes an existing issue. Fill the number below-->
Closes #

<!-- Option 2, this is a small fix that arguably won't need an issue. Uncomment below -->
<!--
There is no related issue.
-->
    init_conf_qr!(mc::MC, ns::Int, N_up::Int)

Ref: Quantum Monte Carlo Approaches for Correlated Systems (Becca and Sorella, 2017) P130

As system size increases, ``<Φ|x>`` becomes exponentially small comparing to system size, inversely proportional to the dimension of the Hilbert space.

The smallness of init ``<Φ|x>`` will lead to numerical instability in the first computation of the W matrices, but not affecting the Markov chain sampling, since we always calculate ``\\frac{<Φ|x'>}{<Φ|x>}`` there, which shall not be a numerically instable number.

To avoid this issue we initializes the particle configurations `kappa_up` and `kappa_down` in the `mc` object
using a deterministic method based on QR decomposition with column pivoting.

This approach is designed to select a set of sites for the up and down spin
electrons that corresponds to a set of linearly independent rows from the `U_up` and
`U_down` matrices, respectively. This maximizes the chances of producing a
non-singular `tilde_U` matrix, avoiding the need for random trial-and-error.

The procedure is as follows:
1.  It performs QR decomposition on `mc.Ham.U_up'` to select the `N_up` most
    linearly independent rows (sites) for the up-spin electrons.
2.  It then takes the remaining, unoccupied sites and performs a second QR
    decomposition on the corresponding subset of `mc.Ham.U_down'` to select the
    `N_down` sites for the down-spin electrons.


## Checklist

<!-- mark true if NA -->
<!-- leave PR as draft until all is checked -->
- [ ] Tests are passing
- [ ] Lint workflow is passing
- [ ] Docs were updated and workflow is passing
